### PR TITLE
Fix options flow deprecation warning

### DIFF
--- a/custom_components/ha_access_control_manager/options_flow.py
+++ b/custom_components/ha_access_control_manager/options_flow.py
@@ -6,9 +6,6 @@ from .const import ICONS
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Access Control Manager."""
 
-    def __init__(self, config_entry):
-        self.config_entry = config_entry
-
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         if user_input is not None:


### PR DESCRIPTION
## Summary
- remove manual assignment of `config_entry` in options flow to rely on Home Assistant base implementation and avoid upcoming deprecation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8966c14883319ebf83e960a98628)