### PR TITLE
Handle options flow config entry in initializer

### DIFF
--- a/custom_components/ha_access_control_manager/options_flow.py
+++ b/custom_components/ha_access_control_manager/options_flow.py
@@ -7,7 +7,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for Access Control Manager."""
 
     def __init__(self, config_entry):
-        self.config_entry = config_entry
+        """Initialize options flow."""
+        super().__init__(config_entry)
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
## Summary
- add options flow initializer that forwards the config entry to the base class to support Home Assistant 2025.12 expectations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b8966c14883319ebf83e960a98628)