### PR TITLE
fix: update ha-dialog usage for HA 2026.3.1

### DIFF
--- a/custom_components/ha_access_control_manager/manifest.json
+++ b/custom_components/ha_access_control_manager/manifest.json
@@ -8,5 +8,5 @@
     "iot_class": "local_push",
     "issue_tracker": "https://github.com/Darkdragon14/ha-access-control-manager/issues",
     "requirements": [],
-    "version": "1.6.1"
+    "version": "1.6.3"
 }

--- a/custom_components/ha_access_control_manager/www/ha-access-control-manager.js
+++ b/custom_components/ha_access_control_manager/www/ha-access-control-manager.js
@@ -1353,7 +1353,7 @@ class AccessControlManager extends LitElement {
                                 </ha-button>
                                 <ha-dialog 
                                     .open=${this.openCreateGroup}
-                                    heading="${this.translate("create_new_group")}" 
+                                    header-title="${this.translate("create_new_group")}" 
                                 >
                                     <div>
                                         <ha-textfield 
@@ -1365,26 +1365,28 @@ class AccessControlManager extends LitElement {
                                             @input="${this.handleNewGroupInput}"
                                         ></ha-textfield>
                                     </div>
-                                    <ha-button
-                                        appearance="plain"
-                                        dialogAction="save"
-                                        slot="primaryAction"
-                                        @click="${this.handleNewGroupSave}"
-                                    >
-                                        ${this.translate("save")}
-                                    </ha-button>
-                                    <ha-button
-                                        appearance="plain"
-                                        dialogAction="cancel"
-                                        slot="secondaryAction"
-                                        @click="${(e) => this.openCreateGroup = false}"
-                                    >
-                                        ${this.translate("cancel")}
-                                    </ha-button>
+                                    <ha-dialog-footer slot="footer">
+                                        <ha-button
+                                            appearance="plain"
+                                            dialogAction="cancel"
+                                            slot="secondaryAction"
+                                            @click="${(e) => this.openCreateGroup = false}"
+                                        >
+                                            ${this.translate("cancel")}
+                                        </ha-button>
+                                        <ha-button
+                                            appearance="plain"
+                                            dialogAction="save"
+                                            slot="primaryAction"
+                                            @click="${this.handleNewGroupSave}"
+                                        >
+                                            ${this.translate("save")}
+                                        </ha-button>
+                                    </ha-dialog-footer>
                                 </ha-dialog>
                                 <ha-dialog
                                     .open=${this.duplicateGroupDialogOpen}
-                                    heading="${this.translate("duplicate_group")}" 
+                                    header-title="${this.translate("duplicate_group")}" 
                                     @closed=${this.closeDuplicateGroupDialog}
                                 >
                                     <div>
@@ -1397,23 +1399,25 @@ class AccessControlManager extends LitElement {
                                             @input="${this.handleDuplicateGroupInput}"
                                         ></ha-textfield>
                                     </div>
-                                    <ha-button
-                                        appearance="plain"
-                                        dialogAction="save"
-                                        slot="primaryAction"
-                                        @click="${this.handleDuplicateGroupSave}"
-                                        .disabled=${this._isSaving}
-                                    >
-                                        ${this.translate("save")}
-                                    </ha-button>
-                                    <ha-button
-                                        appearance="plain"
-                                        dialogAction="cancel"
-                                        slot="secondaryAction"
-                                        @click="${this.closeDuplicateGroupDialog}"
-                                    >
-                                        ${this.translate("cancel")}
-                                    </ha-button>
+                                    <ha-dialog-footer slot="footer">
+                                        <ha-button
+                                            appearance="plain"
+                                            dialogAction="cancel"
+                                            slot="secondaryAction"
+                                            @click="${this.closeDuplicateGroupDialog}"
+                                        >
+                                            ${this.translate("cancel")}
+                                        </ha-button>
+                                        <ha-button
+                                            appearance="plain"
+                                            dialogAction="save"
+                                            slot="primaryAction"
+                                            @click="${this.handleDuplicateGroupSave}"
+                                            .disabled=${this._isSaving}
+                                        >
+                                            ${this.translate("save")}
+                                        </ha-button>
+                                    </ha-dialog-footer>
                                 </ha-dialog>
                             </div>
                         </div>
@@ -1695,23 +1699,25 @@ class AccessControlManager extends LitElement {
         </div>
         <ha-dialog
             .open=${this.restartDialogOpen}
-            heading="${this.translate("confirm_restart_title")}"
+            header-title="${this.translate("confirm_restart_title")}"
             @closed=${this.closeRestartDialog}
         >
             <p>${this.translate("confirm_restart_description")}</p>
-            <ha-button
-                variant="danger"
-                slot="primaryAction"
-                @click=${this.confirmRestart}
-            >
-                ${this.translate("confirm")}
-            </ha-button>
-            <ha-button
-                slot="secondaryAction"
-                @click=${this.closeRestartDialog}
-            >
-                ${this.translate("cancel")}
-            </ha-button>
+            <ha-dialog-footer slot="footer">
+                <ha-button
+                    slot="secondaryAction"
+                    @click=${this.closeRestartDialog}
+                >
+                    ${this.translate("cancel")}
+                </ha-button>
+                <ha-button
+                    variant="danger"
+                    slot="primaryAction"
+                    @click=${this.confirmRestart}
+                >
+                    ${this.translate("confirm")}
+                </ha-button>
+            </ha-dialog-footer>
         </ha-dialog>
         `
     }


### PR DESCRIPTION
## Summary
- update custom `ha-dialog` instances to use the current Home Assistant `header-title` API
- move dialog actions into `ha-dialog-footer` so create, duplicate, and restart modals render correctly on HA Frontend 20260304.0
- bump the integration version to `1.6.3` so the browser fetches the updated panel bundle instead of serving cached JS