### PR TITLE
Show group members for selected groups

### DIFF
--- a/custom_components/ha_access_control_manager/translations/de.json
+++ b/custom_components/ha_access_control_manager/translations/de.json
@@ -152,6 +152,12 @@
             "visible": {
                 "name": "Sichtbar"
             },
+            "group_members_for": {
+                "name": "Gruppenmitglieder für"
+            },
+            "no_users_linked_to_group": {
+                "name": "Keine Benutzer mit dieser Gruppe verknüpft"
+            },
             "helper_permissions_for": {
                 "name": "Helfer-Berechtigungen für"
             },

--- a/custom_components/ha_access_control_manager/translations/en.json
+++ b/custom_components/ha_access_control_manager/translations/en.json
@@ -152,6 +152,12 @@
             "visible": {
                 "name": "Visible"
             },
+            "group_members_for": {
+                "name": "Group members for"
+            },
+            "no_users_linked_to_group": {
+                "name": "No users linked to this group"
+            },
             "helper_permissions_for": {
                 "name": "Helper permissions for"
             },

--- a/custom_components/ha_access_control_manager/translations/es.json
+++ b/custom_components/ha_access_control_manager/translations/es.json
@@ -152,6 +152,12 @@
             "visible": {
                 "name": "Visible"
             },
+            "group_members_for": {
+                "name": "Miembros del grupo para"
+            },
+            "no_users_linked_to_group": {
+                "name": "No hay usuarios vinculados a este grupo"
+            },
             "helper_permissions_for": {
                 "name": "Permisos de helpers para"
             },

--- a/custom_components/ha_access_control_manager/translations/fr.json
+++ b/custom_components/ha_access_control_manager/translations/fr.json
@@ -152,6 +152,12 @@
             "visible": {
                 "name": "Visible"
             },
+            "group_members_for": {
+                "name": "Membres du groupe pour"
+            },
+            "no_users_linked_to_group": {
+                "name": "Aucun utilisateur lié à ce groupe"
+            },
             "helper_permissions_for": {
                 "name": "Autorisations des helpers pour"
             },

--- a/custom_components/ha_access_control_manager/translations/hu.json
+++ b/custom_components/ha_access_control_manager/translations/hu.json
@@ -152,6 +152,12 @@
             "visible": {
                 "name": "Látható"
             },
+            "group_members_for": {
+                "name": "Csoporttagok ehhez"
+            },
+            "no_users_linked_to_group": {
+                "name": "Ehhez a csoporthoz nincs felhasználó kapcsolva"
+            },
             "helper_permissions_for": {
                 "name": "Segédek engedélyei ehhez"
             },

--- a/custom_components/ha_access_control_manager/translations/it.json
+++ b/custom_components/ha_access_control_manager/translations/it.json
@@ -152,6 +152,12 @@
             "visible": {
                 "name": "Visibile"
             },
+            "group_members_for": {
+                "name": "Membri del gruppo per"
+            },
+            "no_users_linked_to_group": {
+                "name": "Nessun utente collegato a questo gruppo"
+            },
             "helper_permissions_for": {
                 "name": "Permessi degli helper per"
             },

--- a/custom_components/ha_access_control_manager/www/ha-access-control-manager.js
+++ b/custom_components/ha_access_control_manager/www/ha-access-control-manager.js
@@ -889,6 +889,35 @@ class AccessControlManager extends LitElement {
         `;
     }
 
+    renderGroupMembersCard() {
+        const selectedGroup = this.getSelectedGroup();
+        if (!selectedGroup) {
+            return null;
+        }
+
+        const linkedUsers = this.getLinkedUsersForGroup(selectedGroup.id);
+        const selectedGroupLabel = selectedGroup.name || selectedGroup.id;
+
+        return html`
+            <ha-card
+                class="group-users-card"
+                header="${this.translate('group_members_for')} ${selectedGroupLabel}"
+            >
+                <div class="group-users-content">
+                    ${linkedUsers.length > 0 ? html`
+                        <ul class="group-users-list">
+                            ${linkedUsers.map(user => html`
+                                <li class="group-users-item">${user.username}</li>
+                            `)}
+                        </ul>
+                    ` : html`
+                        <div class="group-users-empty">${this.translate('no_users_linked_to_group')}</div>
+                    `}
+                </div>
+            </ha-card>
+        `;
+    }
+
     renderInlineRenameGroupButton(group) {
         if (!group || this.isDefaultSystemGroup(group)) {
             return null;
@@ -2138,6 +2167,7 @@ class AccessControlManager extends LitElement {
                     </ha-card>
                     `
                 : html`
+                    ${this.renderGroupMembersCard()}
                     ${this.renderDashboardPermissionsCard()}
                     ${this.renderDevicesPermissionsCard()}
                     ${this.renderEntitiesPermissionsCard()}
@@ -2333,12 +2363,38 @@ class AccessControlManager extends LitElement {
             }
 
             .group-card,
+            .group-users-card,
             .entites-cards,
             .entities-card,
             .dashboards-card,
             .helpers-card,
             .entities-without-devices-card {
                 margin: 10px;
+            }
+
+            .group-users-content {
+                padding: 16px;
+            }
+
+            .group-users-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                max-height: 180px;
+                overflow-y: auto;
+            }
+
+            .group-users-item {
+                padding: 10px 0;
+                color: var(--primary-text-color);
+            }
+
+            .group-users-item + .group-users-item {
+                border-top: 1px solid var(--divider-color);
+            }
+
+            .group-users-empty {
+                color: var(--secondary-text-color);
             }
             
             .group-list {


### PR DESCRIPTION
## Summary
- add a dedicated group members card when a group is selected in the access control manager
- list linked users in a simple vertical layout and keep an empty state when a group has no members
- add translation keys for the new group members copy across supported languages