### PR TITLE
fix: list SSO users for access control

### DIFF
--- a/custom_components/ha_access_control_manager/get_users.py
+++ b/custom_components/ha_access_control_manager/get_users.py
@@ -4,21 +4,33 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant
 from homeassistant.components import websocket_api
 
+
 @websocket_api.websocket_command({vol.Required("type"): "ha_access_control/list_users"})
 @websocket_api.require_admin
 @websocket_api.async_response
 async def list_users(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
-    result = [] 
+    result = []
     for user in await hass.auth.async_get_users():
-        ha_username = next((cred.data.get("username") for cred in user.credentials if cred.auth_provider_type == "homeassistant"), None)
-        if (ha_username is None or user.is_active is False):
+        if not user.is_active or user.system_generated:
             continue
 
-        result.append({
-            "id": user.id,
-            "username": ha_username,
-            "group_ids": [group.id for group in user.groups]
-        })
+        ha_username = next(
+            (
+                credential.data.get("username")
+                for credential in user.credentials
+                if credential.auth_provider_type == "homeassistant"
+            ),
+            None,
+        )
+        display_name = ha_username or user.name or user.id
+
+        result.append(
+            {
+                "id": user.id,
+                "username": display_name,
+                "group_ids": [group.id for group in user.groups],
+            }
+        )
     connection.send_result(msg["id"], result)


### PR DESCRIPTION
## Summary

- include active non-system users regardless of authentication provider
- preserve local usernames while falling back to the Home Assistant display name or user ID
- close #56

## Testing

- `python3 -m compileall -q custom_components/ha_access_control_manager`
- `git diff --check`